### PR TITLE
[CROW1]: Add vertical and horizontal scrollbars

### DIFF
--- a/version1_tkinter/CROW_clusters.py
+++ b/version1_tkinter/CROW_clusters.py
@@ -302,9 +302,7 @@ class ClericalApp:
             command=lambda: self.update_index(1),
             bg="DarkSeaGreen1",
         )
-        self.match_button.grid(
-            row=self.len_current_cluster, column=1, columnspan=1, padx=10, pady=10
-        )
+        self.match_button.grid(row=0, column=0, columnspan=1, padx=15, pady=10)
         self.non_match_button = tkinter.Button(
             self.button_frame,
             text="No more matches",
@@ -312,18 +310,15 @@ class ClericalApp:
             command=lambda: self.update_index(0),
             bg="light salmon",
         )
-        self.non_match_button.grid(
-            row=self.len_current_cluster, column=2, columnspan=1, padx=10, pady=10
-        )
+        self.non_match_button.grid(row=0, column=1, columnspan=1, padx=15, pady=10)
+
         self.back_button = tkinter.Button(
             self.button_frame,
             text="Back",
             font=f"Helvetica {self.text_size}",
             command=lambda: self.go_back(),
         )
-        self.back_button.grid(
-            row=self.len_current_cluster, column=3, columnspan=1, padx=10, pady=10
-        )
+        self.back_button.grid(row=0, column=2, columnspan=1, padx=15, pady=10)
 
         # disable back button if no previous clusters exist
         if self.cluster_index == 0 and self.current_num_cluster_decisions() == 0:
@@ -363,7 +358,30 @@ class ClericalApp:
                 ).split(",")
 
     def draw_tool_frame(self):
-        # =====  tool_frame
+        # Configure the grid so the record counter can move to the right
+        # of the tool frame.
+        self.tool_frame.grid_columnconfigure(9, weight=1)
+
+        # Create separators for tool frame buttons.
+        self.separator_tf_1 = ttk.Separator(self.tool_frame, orient="vertical")
+        self.separator_tf_1.grid(
+            row=0, column=3, rowspan=1, sticky="ns", padx=10, pady=5
+        )
+        self.separator_tf_2 = ttk.Separator(self.tool_frame, orient="vertical")
+        self.separator_tf_2.grid(
+            row=0, column=7, rowspan=1, sticky="ns", padx=10, pady=5
+        )
+
+        # Highlighter.
+        self.highlighter_button = tkinter.Checkbutton(
+            self.tool_frame,
+            indicatoron=False,
+            selectcolor="white",
+            text="show/hide differences",
+            font=f"Helvetica {self.text_size}",
+            command=lambda: self.show_hide_differences(self.show_hide_diff),
+        )
+        self.highlighter_button.grid(row=0, column=2, padx=5, pady=5)
 
         self.text_smaller_button = tkinter.Button(
             self.tool_frame,
@@ -373,7 +391,7 @@ class ClericalApp:
             width=3,
             command=lambda: self.change_text_size(0),
         )
-        self.text_smaller_button.pack(side=tkinter.LEFT, padx=5)
+        self.text_smaller_button.grid(row=0, column=4, sticky="e", pady=5)
 
         self.text_bigger_button = tkinter.Button(
             self.tool_frame,
@@ -383,9 +401,9 @@ class ClericalApp:
             width=3,
             command=lambda: self.change_text_size(1),
         )
-        self.text_bigger_button.pack(side=tkinter.LEFT, padx=5)
+        self.text_bigger_button.grid(row=0, column=5, sticky="w", pady=5, padx=2)
 
-        # Make text bld button
+        # Make text bold button.
         self.bold_button = tkinter.Button(
             self.tool_frame,
             text="B",
@@ -394,53 +412,38 @@ class ClericalApp:
             width=3,
             command=lambda: self.make_text_bold(config, working_file),
         )
-        self.bold_button.pack(side=tkinter.LEFT, padx=5)
+        self.bold_button.grid(row=0, column=6, sticky="w", pady=5)
 
-        # Save and close button
+        # Save and close button.
         self.save_button = tkinter.Button(
             self.tool_frame,
             text="Save and Close",
             font=f"Helvetica {self.text_size}",
             command=lambda: self.save_and_close(),
         )
-        self.save_button.pack(side=tkinter.RIGHT, padx=5)
+        self.save_button.grid(row=0, column=8, sticky="e", padx=5, pady=5)
 
-        # highlighter
-        self.highlighter_button = tkinter.Checkbutton(
-            self.tool_frame,
-            indicatoron=0,
-            selectcolor="white",
-            text="show/hide differences",
-            font=f"Helvetica {self.text_size}",
-            command=lambda: self.show_hide_differences(self.show_hide_diff),
-        )
-        self.highlighter_button.pack(side=tkinter.LEFT, padx=5)
-
-    def draw_recordframe(self, config, working_file):
-        # try to calculate and display remaining # clusters for matching
+        # Current cluster counter.
+        count_msg = f"Cluster: {self.cluster_index + 1} / {self.num_clusters}"
+        # Try to calculate and display remaining # clusters for
+        # matching.
         try:
             self.counter_matches = ttk.Label(
-                self.record_frame,
-                text=f"{self.cluster_index + 1} / {self.num_clusters} Clusters",
-                font=f"Helvetica {self.text_size}",
+                self.tool_frame, text=count_msg, font=f"Helvetica {self.text_size}"
             )
-            self.counter_matches.grid(
-                row=0,
-                column=len(config.options("column_headers_and_order")),
-                columnspan=1,
-                padx=10,
-                sticky="e",
-            )
+            self.counter_matches.grid(row=0, column=9, padx=10, sticky="e")
 
-        # except when matching is completed
+        # Except when matching is completed.
         except TypeError:
             tkinter.messagebox.showinfo(
                 title="Matching completed",
                 message="Please select a different file to clerically match",
             )
 
-            # close down the application
+            # Close down the application.
             root.destroy()
+
+    def draw_recordframe(self, config, working_file):
         num_match_cols = 0
         # Create column header labels and place all them on row 1, column n+1
         for n, column_title in enumerate(config.options("column_headers_and_order")):

--- a/version1_tkinter/CROW_clusters.py
+++ b/version1_tkinter/CROW_clusters.py
@@ -31,27 +31,29 @@ linkage.hub@ons.gov.uk
 We would like to acknowledge and thank David Cobbledick and Andrew Sutton for
 reviewing this code.
 """
+
+import configparser
+import getpass
 import os
 import sys
-import getpass
-import configparser
 import tkinter
-from tkinter import ttk, filedialog
-import pandas as pd
+from tkinter import filedialog, ttk
+
 import numpy as np
+import pandas as pd
+
 
 class IntroWindow:
-    '''
+    """
     intro_window class function - opens a window that prompts the user to
     choose their matching file.
 
-    '''
+    """
 
     def __init__(self, root, init_dir, files_info):
-
         # Initialise the gui paramaters
-        root.geometry('400x225')
-        root.title('Clerical Matching')
+        root.geometry("400x225")
+        root.title("Clerical Matching")
         root.eval("tk::PlaceWindow . center")
 
         # initialise some variables - what are these used for?
@@ -60,68 +62,84 @@ class IntroWindow:
 
         # initialise the frame
         self.content = ttk.Frame(root)
-        self.frame = ttk.Frame(self.content, borderwidth=5, relief='ridge',
-                               width=500, height=300)
+        self.frame = ttk.Frame(
+            self.content, borderwidth=5, relief="ridge", width=500, height=300
+        )
         self.content.grid(column=0, row=0)
         self.frame.grid(column=0, row=0, columnspan=5, rowspan=5)
 
         # create some widgets and place them on the gui
-        self.intro_text = ttk.Label(self.content, text=(
-            'Welcome to the Clerical Matching Application. \nPlease click "Choose File" to select your file \nand begin matching.'), font='Helvetica 10')
+        self.intro_text = ttk.Label(
+            self.content,
+            text=(
+                'Welcome to the Clerical Matching Application. \nPlease click "Choose File" to select your file \nand begin matching.'
+            ),
+            font="Helvetica 10",
+        )
         self.intro_text.grid(row=1, column=0, columnspan=4)
 
         # create the button
         self.choose_file_button = ttk.Button(
-            self.content, text='Choose File', command=lambda: self.open_dirfinder())
-        self.choose_file_button.grid(
-            row=2, column=1, columnspan=1, sticky='new')
+            self.content, text="Choose File", command=lambda: self.open_dirfinder()
+        )
+        self.choose_file_button.grid(row=2, column=1, columnspan=1, sticky="new")
 
     def open_dirfinder(self):
-        '''
+        """
         Opens a file select window, allows user to choose a file. Ends the GUI.
 
         Returns
         -------
         None.
 
-        '''
+        """
         # Open up a window that allows the user to choose a matching file
         self.fileselect = filedialog.askopenfilename(
-            initialdir=self.init_dir, title="Please select a file:", filetypes=self.files_info)
+            initialdir=self.init_dir,
+            title="Please select a file:",
+            filetypes=self.files_info,
+        )
 
         # close down intro_window
         root.destroy()
 
 
 class ClericalApp:
-    '''
+    """
     ClericalApp class function - opens a window and allows users to clerically review records.
 
-    '''
+    """
 
     def __init__(self, root, working_file, filename_done, filename_old, config):
+        """Initialise the ClericalApp class."""
+        # Initialise some parameters.
+        self.root = root
+        self.filename_done = filename_done
+        self.filename_old = filename_old
 
-        # Create a title
-        root.title('Clerical Matching')
-        root.eval("tk::PlaceWindow . center")
+        # Set the window title.
+        root.title("Clerical Matching")
+
+        # Set the window size to 90% of screen width and 50% of screen
+        # height.
+        width = int(self.root.winfo_screenwidth() * 0.9)
+        height = int(self.root.winfo_screenheight() * 0.5)
+        self.root.geometry(f"{width}x{height}")
 
         # Create the separate frames
         # 1 - Tool Frame
-        self.tool_frame = ttk.LabelFrame(root, text='Tools:')
-        self.tool_frame.grid(row=0, column=0, columnspan=1, sticky='ew',
-                            padx=10, pady=10)
+        self.tool_frame = ttk.LabelFrame(root, text="Tools:")
+        self.tool_frame.grid(
+            row=0, column=0, columnspan=1, sticky="ew", padx=10, pady=10
+        )
 
         # 2 - Record Frame
-        self.record_frame = ttk.LabelFrame(root, text='Current Record')
+        self.record_frame = ttk.LabelFrame(root, text="Current Record")
         self.record_frame.grid(row=1, column=0, columnspan=1, padx=10, pady=3)
 
         # 2 - Button Frame
         self.button_frame = ttk.LabelFrame(root)
         self.button_frame.grid(row=2, column=0, columnspan=1, padx=10, pady=3)
-
-        # initalise the file name variables
-        self.filename_done = filename_done
-        self.filename_old = filename_old
 
         # list of record IDs that have not been matched yet
         self.not_matched_yet = []
@@ -130,47 +148,42 @@ class ClericalApp:
         root.protocol("WM_DELETE_WINDOW", self.on_exit)
 
         # if match column exists in clerical file
-        if {'Match'}.issubset(working_file.columns):
-
+        if {"Match"}.issubset(working_file.columns):
             # variable indicates whether user has returned to this file (1) or not (0)
             self.matching_previously_began = 1
 
         else:
-
             # create a match column and fill with blanks
-            working_file['Match'] = ''
+            working_file["Match"] = ""
 
             self.matching_previously_began = 0
 
         # convert all columns apart from Match and Comments (if specified) to string
         for col_header in working_file.columns:
-
-            if col_header in ('Match', 'Comments'):
+            if col_header in ("Match", "Comments"):
                 pass
             else:
                 # convert to string
                 working_file[col_header] = working_file[col_header].astype(str)
                 # remove nan values
                 for i in range(len(working_file)):
-
                     # should this be 'NaN' after casting to str?
-                    if working_file[col_header][i] == 'nan':
+                    if working_file[col_header][i] == "nan":
+                        working_file.at[i, col_header] = ""
 
-                        working_file.at[i, col_header] = ''
-
-        working_file.fillna('', inplace=True)
+        working_file.fillna("", inplace=True)
 
         # a counter of the number of checkpoint saves.
         self.checkpointcounter = 0
 
         # create a sequential cluster id number from the cluster id variable
-        cluster_var = config['cluster_id_number']['cluster_id']
-        working_file['cluster_sequential_number'] = pd.factorize(
-            working_file[cluster_var])[0]
+        cluster_var = config["cluster_id_number"]["cluster_id"]
+        working_file["cluster_sequential_number"] = pd.factorize(
+            working_file[cluster_var]
+        )[0]
 
         # list of cluster numbers over which to iterate
-        clusters_to_iterate = list(
-            working_file['cluster_sequential_number'].unique())
+        clusters_to_iterate = list(working_file["cluster_sequential_number"].unique())
 
         # counter variable for iterating through the CM file
         # For multiple records version use cluster ids
@@ -182,23 +195,25 @@ class ClericalApp:
         self.num_clusters = len(clusters_to_iterate)
 
         # get a list of the indices of the records contained within the current cluster.
-        self.display_indexes = working_file.index[working_file['cluster_sequential_number'] == self.cluster_index].to_list(
-        )
+        self.display_indexes = working_file.index[
+            working_file["cluster_sequential_number"] == self.cluster_index
+        ].to_list()
 
         # create a variable that indicates the length of the current cluster
         self.len_current_cluster = len(
-            working_file['cluster_sequential_number'] == self.cluster_index)
+            working_file["cluster_sequential_number"] == self.cluster_index
+        )
 
         # create an empty string to record results
-        self.match_string = ''
+        self.match_string = ""
 
         # create the text size component
         self.text_size = 10
         self.text_bold_boolean = 0
-        self.text_bold = ''
+        self.text_bold = ""
 
         self.style = ttk.Style()
-        self.style.configure('.', font=('Helvetica', f'{self.text_size}'))
+        self.style.configure(".", font=("Helvetica", f"{self.text_size}"))
 
         # SHOW/HIDE DIFFERENCES CLASS VARAIBLES
         # toggle on and off
@@ -225,201 +240,280 @@ class ClericalApp:
         returns the cluster id of the first cluster that does not have a value in the match field.
         """
         for i in working_file.index:
-            if working_file.loc[i, 'Match'] == '':
-                return working_file.loc[i, 'cluster_sequential_number']
+            if working_file.loc[i, "Match"] == "":
+                return working_file.loc[i, "cluster_sequential_number"]
             else:
                 pass
 
     def draw_button_frame(self):
         # =====  button_frame - for match/non-match/back buttons
 
-        self.match_button = tkinter.Button(self.button_frame, text='Match',
-                                   font=f'Helvetica {self.text_size}',
-                                   command=lambda: self.update_index(1),
-                                   bg='DarkSeaGreen1')
-        self.match_button.grid(row=self.len_current_cluster,
-                               column=1, columnspan=1, padx=10, pady=10)
-        self.non_match_button = tkinter.Button(self.button_frame,
-                                       text='No more matches',
-                                       font=f'Helvetica {self.text_size}',
-                                       command=lambda: self.update_index(0),
-                                       bg='light salmon')
+        self.match_button = tkinter.Button(
+            self.button_frame,
+            text="Match",
+            font=f"Helvetica {self.text_size}",
+            command=lambda: self.update_index(1),
+            bg="DarkSeaGreen1",
+        )
+        self.match_button.grid(
+            row=self.len_current_cluster, column=1, columnspan=1, padx=10, pady=10
+        )
+        self.non_match_button = tkinter.Button(
+            self.button_frame,
+            text="No more matches",
+            font=f"Helvetica {self.text_size}",
+            command=lambda: self.update_index(0),
+            bg="light salmon",
+        )
         self.non_match_button.grid(
-            row=self.len_current_cluster, column=2, columnspan=1, padx=10, pady=10)
-        self.back_button = tkinter.Button(self.button_frame, text='Back',
-                                  font=f'Helvetica {self.text_size}',
-                                  command=lambda: self.go_back())
-        self.back_button.grid(row=self.len_current_cluster,
-                              column=3, columnspan=1, padx=10, pady=10)
+            row=self.len_current_cluster, column=2, columnspan=1, padx=10, pady=10
+        )
+        self.back_button = tkinter.Button(
+            self.button_frame,
+            text="Back",
+            font=f"Helvetica {self.text_size}",
+            command=lambda: self.go_back(),
+        )
+        self.back_button.grid(
+            row=self.len_current_cluster, column=3, columnspan=1, padx=10, pady=10
+        )
 
         # disable back button if no previous clusters exist
         if self.cluster_index == 0 and self.current_num_cluster_decisions() == 0:
             self.back_button.config(state=tkinter.DISABLED)
 
         # Add in the comment widget based on config option
-        if int(config['custom_settings']['commentbox']):
-
+        if int(config["custom_settings"]["commentbox"]):
             # create comments column if one doesn't exist
-            if 'Comments' not in working_file:
-                working_file['Comments'] = ''
+            if "Comments" not in working_file:
+                working_file["Comments"] = ""
 
             # Get the position info from button 1
             info_button = self.match_button.grid_info()
 
-            self.comment_label = ttk.Label(self.button_frame, text='Comment:',
-                                           font=f'Helvetica {self.text_size} bold')
+            self.comment_label = ttk.Label(
+                self.button_frame,
+                text="Comment:",
+                font=f"Helvetica {self.text_size} bold",
+            )
             self.comment_label.grid(
-                row=info_button['row']+1, column=0, columnspan=1, sticky='e')
+                row=info_button["row"] + 1, column=0, columnspan=1, sticky="e"
+            )
 
             self.comment_entry = ttk.Combobox(self.button_frame)
             self.comment_entry.grid(
-                row=info_button['row']+1, column=1, columnspan=3, sticky='sew', padx=5, pady=5)
+                row=info_button["row"] + 1,
+                column=1,
+                columnspan=3,
+                sticky="sew",
+                padx=5,
+                pady=5,
+            )
 
-            if (config['custom_settings']['comment_values']) is not None:
-                self.comment_entry['values'] = (
-                    config['custom_settings']['comment_values']).split(",")
+            if (config["custom_settings"]["comment_values"]) is not None:
+                self.comment_entry["values"] = (
+                    config["custom_settings"]["comment_values"]
+                ).split(",")
 
     def draw_tool_frame(self):
         # =====  tool_frame
 
-        self.text_smaller_button = tkinter.Button(self.tool_frame, font=f'Helvetica {self.text_size}',
-                                          text='A-', height=1, width=3,
-                                          command=lambda: self.change_text_size(0))
+        self.text_smaller_button = tkinter.Button(
+            self.tool_frame,
+            font=f"Helvetica {self.text_size}",
+            text="A-",
+            height=1,
+            width=3,
+            command=lambda: self.change_text_size(0),
+        )
         self.text_smaller_button.pack(side=tkinter.LEFT, padx=5)
 
-        self.text_bigger_button = tkinter.Button(self.tool_frame, font=f'Helvetica {self.text_size}',
-                                            text='A+', height=1, width=3,
-                                            command=lambda: self.change_text_size(1))
+        self.text_bigger_button = tkinter.Button(
+            self.tool_frame,
+            font=f"Helvetica {self.text_size}",
+            text="A+",
+            height=1,
+            width=3,
+            command=lambda: self.change_text_size(1),
+        )
         self.text_bigger_button.pack(side=tkinter.LEFT, padx=5)
 
         # Make text bld button
-        self.bold_button = tkinter.Button(self.tool_frame, text='B',
-                                     font=f'Helvetica {self.text_size} bold', height=1, width=3,
-                                     command=lambda: self.make_text_bold(config, working_file))
+        self.bold_button = tkinter.Button(
+            self.tool_frame,
+            text="B",
+            font=f"Helvetica {self.text_size} bold",
+            height=1,
+            width=3,
+            command=lambda: self.make_text_bold(config, working_file),
+        )
         self.bold_button.pack(side=tkinter.LEFT, padx=5)
 
         # Save and close button
-        self.save_button = tkinter.Button(self.tool_frame, text='Save and Close',
-                                     font=f'Helvetica {self.text_size}',
-                                     command=lambda: self.save_and_close())
+        self.save_button = tkinter.Button(
+            self.tool_frame,
+            text="Save and Close",
+            font=f"Helvetica {self.text_size}",
+            command=lambda: self.save_and_close(),
+        )
         self.save_button.pack(side=tkinter.RIGHT, padx=5)
 
         # highlighter
-        self.highlighter_button = tkinter.Checkbutton(self.tool_frame, indicatoron=0,
-                                                 selectcolor="white", text='show/hide differences',
-                                                 font=f'Helvetica {self.text_size}',
-                                                 command=lambda: self.show_hide_differences(self.show_hide_diff))
+        self.highlighter_button = tkinter.Checkbutton(
+            self.tool_frame,
+            indicatoron=0,
+            selectcolor="white",
+            text="show/hide differences",
+            font=f"Helvetica {self.text_size}",
+            command=lambda: self.show_hide_differences(self.show_hide_diff),
+        )
         self.highlighter_button.pack(side=tkinter.LEFT, padx=5)
 
     def draw_recordframe(self, config, working_file):
-
         # try to calculate and display remaining # clusters for matching
         try:
-            self.counter_matches = ttk.Label(self.record_frame,
-                                               text=f'{self.cluster_index+1} / {self.num_clusters} Clusters',
-                                               font=f'Helvetica {self.text_size}')
-            self.counter_matches.grid(row=0,
-                                      column=len(config.options('column_headers_and_order')),
-                                      columnspan=1, padx=10, sticky="e")
+            self.counter_matches = ttk.Label(
+                self.record_frame,
+                text=f"{self.cluster_index + 1} / {self.num_clusters} Clusters",
+                font=f"Helvetica {self.text_size}",
+            )
+            self.counter_matches.grid(
+                row=0,
+                column=len(config.options("column_headers_and_order")),
+                columnspan=1,
+                padx=10,
+                sticky="e",
+            )
 
         # except when matching is completed
         except TypeError:
-
-            tkinter.messagebox.showinfo(title="Matching completed",
-                                   message="Please select a different file to clerically match")
+            tkinter.messagebox.showinfo(
+                title="Matching completed",
+                message="Please select a different file to clerically match",
+            )
 
             # close down the application
             root.destroy()
         num_match_cols = 0
         # Create column header labels and place all them on row 1, column n+1
-        for n, column_title in enumerate(config.options('column_headers_and_order')):
-
+        for n, column_title in enumerate(config.options("column_headers_and_order")):
             # Remove spaces from the user input and split them into different components
 
-            col_header = config['column_headers_and_order'][column_title].replace(
-                ' ', '').split(',')
+            col_header = (
+                config["column_headers_and_order"][column_title]
+                .replace(" ", "")
+                .split(",")
+            )
 
-            exec(f'self.{column_title} = ttk.Label(self.record_frame,text="{col_header[0]}",\
-                                                      font=f"Helvetica {self.text_size} bold")')
+            exec(
+                f'self.{column_title} = ttk.Label(self.record_frame,text="{col_header[0]}",\
+                                                      font=f"Helvetica {self.text_size} bold")'
+            )
 
-            exec(f'self.{column_title}.grid(row=1,column=n+1,columnspan=1, sticky = tkinter.W,\
-                                            padx=10, pady=3)')
+            exec(
+                f"self.{column_title}.grid(row=1,column=n+1,columnspan=1, sticky = tkinter.W,\
+                                            padx=10, pady=3)"
+            )
 
             # Add the executed self.labels for the column headers to the non_iterated_labels list
             self.non_iterated_labels.append(column_title)
             num_match_cols += 1
 
         # iterate over column info and order.
-        for n, columnfile_title in enumerate(config.options('columnfile_info_and_order')):
-
+        for n, columnfile_title in enumerate(
+            config.options("columnfile_info_and_order")
+        ):
             row_num = 3
             sep_row = 4
 
             # create a style for header separator
             styl = ttk.Style()
-            styl.configure('grey.TSeparator', background='Wheat4')
+            styl.configure("grey.TSeparator", background="Wheat4")
             header_separator = ttk.Separator(
-                self.record_frame,  orient='horizontal', styl='grey.TSeparator')
+                self.record_frame, orient="horizontal", styl="grey.TSeparator"
+            )
             if self.text_size != 10:
-                text_size_multiplier = (1+((self.text_size-10)/10))
+                text_size_multiplier = 1 + ((self.text_size - 10) / 10)
 
             elif self.text_size == 10:
                 text_size_multiplier = 1
 
                 # grid separator
-            header_separator.grid(row=2, column=0, columnspan=num_match_cols+1, sticky='ns',
-                                  ipadx=80*(num_match_cols+1)*text_size_multiplier, ipady=1)
+            header_separator.grid(
+                row=2,
+                column=0,
+                columnspan=num_match_cols + 1,
+                sticky="ns",
+                ipadx=80 * (num_match_cols + 1) * text_size_multiplier,
+                ipady=1,
+            )
 
             for v, display_i in enumerate(self.display_indexes):
-
-                col_header = config['columnfile_info_and_order'][columnfile_title].replace(
-                    ' ', '').split(',')
+                col_header = (
+                    config["columnfile_info_and_order"][columnfile_title]
+                    .replace(" ", "")
+                    .split(",")
+                )
 
                 # create a text label
-                exec(f'self.{col_header[0]}row{v} = tkinter.Text(self.record_frame,\
-                                                            height=1,relief="flat",bg="gray93")')
+                exec(
+                    f'self.{col_header[0]}row{v} = tkinter.Text(self.record_frame,\
+                                                            height=1,relief="flat",bg="gray93")'
+                )
 
                 # Enter in the text from the df
-                exec(f'self.{col_header[0]}row{v}.insert("1.0",working_file["{col_header[0]}"][{display_i}])')
+                exec(
+                    f'self.{col_header[0]}row{v}.insert("1.0",working_file["{col_header[0]}"][{display_i}])'
+                )
 
                 # configure Text so that it is a specified width, font and cant be interacted with
-                exec(f'self.{col_header[0]}row{v}.config(width=len(working_file["{col_header[0]}"][{display_i}])+10,\
+                exec(
+                    f'self.{col_header[0]}row{v}.config(width=len(working_file["{col_header[0]}"][{display_i}])+10,\
                                                          font=f"Helvetica {self.text_size} {self.text_bold}",\
-                                                         state=tkinter.DISABLED)')
+                                                         state=tkinter.DISABLED)'
+                )
 
                 # grid the text label to the widget.
-                exec(f'self.{col_header[0]}row{v}.grid(row={row_num}, column={n+1},columnspan=1,\
-                                                       padx=10, pady=3,sticky="w")')
+                exec(
+                    f'self.{col_header[0]}row{v}.grid(row={row_num}, column={n + 1},columnspan=1,\
+                                                       padx=10, pady=3,sticky="w")'
+                )
 
                 # create a checkbutton and append it to the list of checkbutton variables.
-                exec(f'self.check_{v}= tkinter.IntVar()')
-                exec(f'self.checkbutton{v}=tkinter.Checkbutton(self.record_frame,\
-                                                          variable=self.check_{v})')
-                exec(f'self.checkbutton{v}.deselect()')
-                exec(f'self.checkbutton{v}.grid(row={row_num}, column=0)')
+                exec(f"self.check_{v}= tkinter.IntVar()")
+                exec(
+                    f"self.checkbutton{v}=tkinter.Checkbutton(self.record_frame,\
+                                                          variable=self.check_{v})"
+                )
+                exec(f"self.checkbutton{v}.deselect()")
+                exec(f"self.checkbutton{v}.grid(row={row_num}, column=0)")
 
-                exec(f"rf_separator{v}=ttk.Separator(self.record_frame, orient='horizontal')")
-                exec(f"rf_separator{v}.grid(row={sep_row}, column=0,\
+                exec(
+                    f"rf_separator{v}=ttk.Separator(self.record_frame, orient='horizontal')"
+                )
+                exec(
+                    f"rf_separator{v}.grid(row={sep_row}, column=0,\
                                             columnspan={num_match_cols}+1, sticky='ns',\
-                                            ipadx=80*({num_match_cols+1})*{text_size_multiplier},\
-                                            ipady=1)")
+                                            ipadx=80*({num_match_cols + 1})*{text_size_multiplier},\
+                                            ipady=1)"
+                )
 
                 if col_header[0] not in self.columns_to_compare:
                     self.columns_to_compare.append(col_header[0])
 
                 # if match column not populated yet, keep checkbutton clickable
-                if working_file.loc[display_i, 'Match'] == "":
-                    exec(f'self.checkbutton{v}.config(state=tkinter.NORMAL)')
+                if working_file.loc[display_i, "Match"] == "":
+                    exec(f"self.checkbutton{v}.config(state=tkinter.NORMAL)")
 
                 # else make it unclickable
                 else:
-                    exec(f'self.checkbutton{v}.config(state=tkinter.DISABLED)')
+                    exec(f"self.checkbutton{v}.config(state=tkinter.DISABLED)")
 
                 row_num += 2
                 sep_row += 2
 
     def update_gui(self, config, working_file):
-        '''
+        """
         A simple function that updates the different GUI labels based on the
         records. This function is called whenever the app is interacted with,
         i.e. when pressing match/non-match/back buttons.
@@ -432,21 +526,18 @@ class ClericalApp:
         -------
         None.
 
-        '''
+        """
 
         # # if commentbox specified in config
 
         # clear recordframe
         for widget in self.record_frame.winfo_children():
-
             widget.destroy()
 
         for widget in self.tool_frame.winfo_children():
-
             widget.destroy()
 
         for widget in self.button_frame.winfo_children():
-
             widget.destroy()
 
         # redraw everything in record_frame
@@ -455,14 +546,14 @@ class ClericalApp:
         self.draw_tool_frame()
 
         # clear commentbox entry
-        if int(config['custom_settings']['commentbox']):
+        if int(config["custom_settings"]["commentbox"]):
             self.comment_entry.delete(0, tkinter.END)
 
         # disable back button if no previous clusters exist
         if self.cluster_index == 0 and self.current_num_cluster_decisions() == 0:
             self.back_button.config(state=tkinter.DISABLED)
         else:
-            self.back_button.config(state='normal')
+            self.back_button.config(state="normal")
 
         self.tags_container = {}
         self.comparison_values = {}
@@ -471,21 +562,21 @@ class ClericalApp:
             self.show_hide_differences(0)
 
     def make_text_bold(self, config, working_file):
-        '''
+        """
         Makes the text bold or not
 
         Returns
         -------
         None.
 
-        '''
+        """
         if not self.text_bold_boolean:
             self.text_bold_boolean = 1
-            self.text_bold = 'bold'
+            self.text_bold = "bold"
 
         else:
             self.text_bold_boolean = 0
-            self.text_bold = ''
+            self.text_bold = ""
 
         # update the gui
         self.update_gui(config, working_file)
@@ -504,20 +595,20 @@ class ClericalApp:
 
         # add to the list of matches; the index of any that are selected by the checkbox.
         for v, display_i in enumerate(self.display_indexes):
-
-            status = eval(f'self.check_{v}.get()')
+            status = eval(f"self.check_{v}.get()")
             if status:
                 list_of_matches.append(display_i)
 
         # creates a string that is the record id's that match; separated by a comma
         # assign string to global variable self.match_string
         for i in list_of_matches:
-            temp_string = str(
-                working_file[config['record_id_col']['record_id']][i]) + ','
+            temp_string = (
+                str(working_file[config["record_id_col"]["record_id"]][i]) + ","
+            )
             self.match_string = self.match_string + temp_string
 
     def current_num_cluster_decisions(self):
-        '''
+        """
         Returns the number of records in the currently selected cluster that have been marked
         as a match.
 
@@ -529,19 +620,21 @@ class ClericalApp:
         -------
         current_num_cluster_decisions: integer
 
-        '''
+        """
         # list containing all record IDs for records marked as matches in current cluster
         current_cluster_decisions = [
-            working_file.loc[i, 'Match'] for i in self.display_indexes]
+            working_file.loc[i, "Match"] for i in self.display_indexes
+        ]
 
         # counting records as a match if there's something in their corresponding match column
         current_num_cluster_decisions = len(
-            [record for record in current_cluster_decisions if record != ""])
+            [record for record in current_cluster_decisions if record != ""]
+        )
 
         return current_num_cluster_decisions
 
     def update_df(self, event):
-        '''
+        """
         Updates the dataframe with the matching outcome when the match button is selected
 
         Parameters
@@ -553,32 +646,31 @@ class ClericalApp:
         -------
         None.
 
-        '''
+        """
         # create a list of checkboxes ticked by the user
         checkboxes_selected = self.match_string.split(",")
 
         # if match button pressed
         if event == 1:
-
             # for each record in the current cluster
             for i in self.display_indexes:
-
                 # if 1 or 0 records are selected, present user with warning
                 if len(checkboxes_selected) <= 2:
-
                     tkinter.messagebox.showwarning(
-                        message="Two or more records must be selected to make a match")
+                        message="Two or more records must be selected to make a match"
+                    )
 
                     break
 
                 # otherwise if the match column is currently empty
-                if working_file.loc[i, 'Match'] == "":
-
+                if working_file.loc[i, "Match"] == "":
                     # if a record is selected by checkbutton
-                    if working_file[config['record_id_col']['record_id']][i] in self.match_string:
-
+                    if (
+                        working_file[config["record_id_col"]["record_id"]][i]
+                        in self.match_string
+                    ):
                         # append currently selected records' record ids to the match column
-                        working_file.loc[i, 'Match'] = self.match_string
+                        working_file.loc[i, "Match"] = self.match_string
 
                         # remove matched records in cluster from list of those not yet matched
                         try:
@@ -586,71 +678,62 @@ class ClericalApp:
 
                         # for cases where matched records have already been removed (big clusters)
                         except ValueError:
-
                             pass
 
                         # if commentbox specified in config
-                        if int(config['custom_settings']['commentbox']):
-
+                        if int(config["custom_settings"]["commentbox"]):
                             # for each row where checkbox selected, append the commentbox contents
-                            working_file.loc[i,
-                                             'Comments'] = self.comment_entry.get()
+                            working_file.loc[i, "Comments"] = self.comment_entry.get()
 
                     # append those not selected by checkbutton to list of those not yet matched
                     else:
-
                         self.not_matched_yet.append(i)
                 else:
                     pass
 
             # if there are 1 or 0 records remaining without matching decisions
             if (len(self.display_indexes) - self.current_num_cluster_decisions()) <= 1:
-
                 # for this remaining record, mark as a non-match
                 for i in self.not_matched_yet:
-
-                    working_file.loc[i, 'Match'] = "No match in cluster"
+                    working_file.loc[i, "Match"] = "No match in cluster"
 
         # if non-match button clicked
         else:
             # mark each record in cluster that has a null match decision as a non-match
             for i in self.display_indexes:
-
-                if working_file.loc[i, 'Match'] == "":
-
-                    working_file.loc[i, 'Match'] = "No match in cluster"
+                if working_file.loc[i, "Match"] == "":
+                    working_file.loc[i, "Match"] = "No match in cluster"
 
                     # if commentbox specified in config
-                    if int(config['custom_settings']['commentbox']):
-
-                        working_file.loc[i,
-                                         'Comments'] = self.comment_entry.get()
+                    if int(config["custom_settings"]["commentbox"]):
+                        working_file.loc[i, "Comments"] = self.comment_entry.get()
 
     def go_back(self):
-        '''
+        """
         A function that goes back to the previous record.
 
         Returns
         -------
         None.
 
-        '''
+        """
         # get the number of decisions made in current cluster
         num_decisions = self.current_num_cluster_decisions()
 
         # update cluster_index IF there are no descisions in current cluster
         if num_decisions == 0:
             self.cluster_index -= 1
-            self.display_indexes = working_file.index[working_file['cluster_sequential_number'] == self.cluster_index].to_list(
-            )
+            self.display_indexes = working_file.index[
+                working_file["cluster_sequential_number"] == self.cluster_index
+            ].to_list()
 
         # reset new (previous record) to empty strings
         for i in self.display_indexes:
-            working_file.loc[i, 'Match'] = ""
-            working_file.loc[i, 'Comments'] = ""
+            working_file.loc[i, "Match"] = ""
+            working_file.loc[i, "Comments"] = ""
 
         # clean the match string
-        self.match_string = ''
+        self.match_string = ""
 
         # clear list of not matched yet
         self.not_matched_yet.clear()
@@ -659,8 +742,8 @@ class ClericalApp:
         self.update_gui(config, working_file)
 
         # configure match_buttons to normal
-        self.match_button.config(state='normal')
-        self.non_match_button.config(state='normal')
+        self.match_button.config(state="normal")
+        self.non_match_button.config(state="normal")
 
         # handling when user presses back button on the first cluster in the data
         try:
@@ -669,7 +752,7 @@ class ClericalApp:
             pass
 
     def check_matching_done(self):
-        '''
+        """
         This function checks if the number of iterations is greater than the number of
         rows; and breaks the loop if so.
 
@@ -680,24 +763,24 @@ class ClericalApp:
         1 = Stop The GUI
         0 = Continue updating the GUI
 
-        '''
+        """
         # Query whether the current record matches the total number of records
-        if self.cluster_index > (self.num_clusters-1):
+        if self.cluster_index > (self.num_clusters - 1):
             # disable the match and Non-match buttons
             self.match_button.configure(state=tkinter.DISABLED)
             self.non_match_button.configure(state=tkinter.DISABLED)
             # inform the user that matching is finished
             self.matchdone = ttk.Label(
-                root, text='Matching Finished. Press save and close.', foreground='red')
+                root, text="Matching Finished. Press save and close.", foreground="red"
+            )
             self.matchdone.grid(row=1, column=0, columnspan=1)
 
             return 1
         else:
-
             return 0
 
     def save_and_close(self):
-        '''
+        """
         This function saves the working_file dataframe and closes the GUI
 
         Parameters
@@ -709,7 +792,7 @@ class ClericalApp:
         -------
         None.
 
-        '''
+        """
         try:
             # Check whether matching has now finished (i.e. they have completed all records)
             if self.cluster_index == (self.num_clusters):
@@ -725,10 +808,12 @@ class ClericalApp:
             root.destroy()
         except PermissionError:
             tkinter.messagebox.showwarning(
-                message="This clerical sample is already open in another program. Please close that program.")
+                message="This clerical sample is already open in another program. Please close that program."
+            )
 
             print(
-                "\nThis clerical sample is already open in another program. Please close that program.")
+                "\nThis clerical sample is already open in another program. Please close that program."
+            )
 
     def show_hide_differences(self, toggle):
         """
@@ -743,7 +828,6 @@ class ClericalApp:
 
         """
         if toggle == 0:
-
             # make show show diff variable 1 so that next time this function is
             # called it will remove tags
             self.show_hide_diff = 1
@@ -751,16 +835,19 @@ class ClericalApp:
             # For the first row in the cluster: for each column to compare;
             # add col and value to self.comparisso_values
             for col in self.columns_to_compare:
-                self.comparison_values[col] = working_file.loc[self.display_indexes[0], col]
+                self.comparison_values[col] = working_file.loc[
+                    self.display_indexes[0], col
+                ]
 
                 # create a dictionary for the current comparison
                 current_comparison = {}
 
                 # for each comparison row
                 for n, current_comparison_row in enumerate(self.display_indexes[1:]):
-
                     # create column:value pair
-                    current_comparison[col] = working_file.loc[current_comparison_row, col]
+                    current_comparison[col] = working_file.loc[
+                        current_comparison_row, col
+                    ]
                     # For the values in datarows that need to be highlighted
 
                     # some empty variables to control the flow of the difference indicator
@@ -774,12 +861,11 @@ class ClericalApp:
                     count = 0
 
                     # zip comparison values and current comparison and compare each zipped item
-                    for char_comparison, char_highlight in zip(self.comparison_values[col],
-                                                               current_comparison[col]):
-
+                    for char_comparison, char_highlight in zip(
+                        self.comparison_values[col], current_comparison[col]
+                    ):
                         # if the comparison char is not the same as the highlighter char
                         if char_comparison != char_highlight:
-
                             # if this is the first diff append count to container
                             if string_start:
                                 # start the container values
@@ -788,10 +874,15 @@ class ClericalApp:
                                 string_start = 0
 
                             # if we are at the end of string comparison
-                            if count == min(len(self.comparison_values[col]),
-                                            len(current_comparison[col]))-1:
-
-                                container.append(count+1)
+                            if (
+                                count
+                                == min(
+                                    len(self.comparison_values[col]),
+                                    len(current_comparison[col]),
+                                )
+                                - 1
+                            ):
+                                container.append(count + 1)
                                 # pass this start and end values to the overall container
                                 char_consistent.append(container)
 
@@ -813,41 +904,43 @@ class ClericalApp:
 
                     # for each tag # in char consistent create the tag and save the tag name
                     for tag_adder in range(len(char_consistent)):
-
                         if col in self.tags_container:
-
-                            temp_val = f'{col}_diff{str(tag_adder)}'
+                            temp_val = f"{col}_diff{str(tag_adder)}"
                             if temp_val not in self.tags_container[col]:
-                                self.tags_container[col].append(f'{col}_diff{str(tag_adder)}')
+                                self.tags_container[col].append(
+                                    f"{col}_diff{str(tag_adder)}"
+                                )
 
                         else:
+                            self.tags_container[col] = [f"{col}_diff{str(tag_adder)}"]
 
-                            self.tags_container[col] = [f'{col}_diff{str(tag_adder)}']
-
-                        exec(f'self.{col}row{n+1}.tag_add(f"{col}_diff{str(tag_adder)}",\
+                        exec(
+                            f'self.{col}row{n + 1}.tag_add(f"{col}_diff{str(tag_adder)}",\
                                                           f"1.{char_consistent[tag_adder][0]}",\
-                                                          f"1.{char_consistent[tag_adder][-1]}")')
+                                                          f"1.{char_consistent[tag_adder][-1]}")'
+                        )
 
-                        exec(f'self.{col}row{n+1}.tag_config(f"{col}_diff{str(tag_adder)}",\
+                        exec(
+                            f'self.{col}row{n + 1}.tag_config(f"{col}_diff{str(tag_adder)}",\
                                                              background="yellow",\
-                                                             foreground = "black")')
+                                                             foreground = "black")'
+                        )
 
         else:
             # reset this variable
             self.show_hide_diff = 1
 
             # for all variable labels with differences - remove the tag labels
-            for n in range(0, len(self.display_indexes)-1):
-
+            for n in range(0, len(self.display_indexes) - 1):
                 # for columns in self.columns_to_compare:
                 for col, value in self.tags_container.items():
                     for item in value:
-                        exec(f"self.{col}row{n+1}.tag_remove('{item}','1.0','end')")
+                        exec(f"self.{col}row{n + 1}.tag_remove('{item}','1.0','end')")
 
             self.show_hide_diff = 0
 
     def update_index(self, event):
-        '''
+        """
         This function updates the overall index variable which cycles through
         the Clerical Matching (CM) file. Additional functonality is directing
         to other functions to update the CM file and finally updating the GUI
@@ -862,7 +955,7 @@ class ClericalApp:
         -------
         None.
 
-         '''
+        """
 
         # Update the list of matching record IDs
         self.get_matches()
@@ -874,22 +967,25 @@ class ClericalApp:
         self.update_gui(config, working_file)
 
         # reset match string so different pairings can be made in that cluster
-        self.match_string = ''
+        self.match_string = ""
 
         # clear the list of records in cluster remaining unmatched
         self.not_matched_yet.clear()
 
         # if match button has been clicked and there are still unmatched records in cluster
-        if len(self.display_indexes) > self.current_num_cluster_decisions() and event == 1:
+        if (
+            len(self.display_indexes) > self.current_num_cluster_decisions()
+            and event == 1
+        ):
             pass
 
         # if no more matches can be made in cluster OR no more matches button is clicked
         else:
-
             # update the cluster_index and display indexes to referece the new cluster
             self.cluster_index += 1
-            self.display_indexes = working_file.index[working_file['cluster_sequential_number'] == self.cluster_index].to_list(
-            )
+            self.display_indexes = working_file.index[
+                working_file["cluster_sequential_number"] == self.cluster_index
+            ].to_list()
             self.len_current_cluster = len(self.display_indexes)
 
             stp_gui = self.check_matching_done()
@@ -904,7 +1000,7 @@ class ClericalApp:
                 self.update_gui(config, working_file)
 
     def change_text_size(self, size_change):
-        '''
+        """
         This function will increase or decrease the size of the text. It then
         updates the GUI.
         It also changes the size of the window to fit the text.
@@ -918,7 +1014,7 @@ class ClericalApp:
         -------
         None.
 
-        '''
+        """
         # depending on the argument passed - increase/decrease text size/geometry paramaters
         if size_change:
             self.text_size += 1
@@ -930,27 +1026,29 @@ class ClericalApp:
         self.update_gui(config, working_file)
 
     def on_exit(self):
-        '''
+        """
         When you click to exit, this function is called, which creates a message
         box that questions whether the user wants to Exit without saving
 
-        '''
+        """
         # if they click yes
 
-        if tkinter.messagebox.askyesno("Exit", "Are you sure you want to exit WITHOUT saving?"):
-
+        if tkinter.messagebox.askyesno(
+            "Exit", "Are you sure you want to exit WITHOUT saving?"
+        ):
             # check if this is the first time they are accessing it
             if not self.matching_previously_began & self.checkpointcounter == 0:
                 # then rename the file removing their intial and 'inProgress' tag
-                os.rename(self.filename_old, '_'.join(
-                    self.filename_old.split('_')[0:-2]) + '.csv')
+                os.rename(
+                    self.filename_old,
+                    "_".join(self.filename_old.split("_")[0:-2]) + ".csv",
+                )
 
             # close down the application
             root.destroy()
 
 
 if __name__ == "__main__":
-
     # ------
     # Step 1:
     # Load config file and get the file directory
@@ -960,13 +1058,13 @@ if __name__ == "__main__":
 
     # Import the configs for the project
     config = configparser.ConfigParser()
-    config.read('Config_clusters.ini')
+    config.read("Config_clusters.ini")
 
     # Get the initial directory folder
-    initdir = config['matching_files_details']['file_pathway']
+    initdir = config["matching_files_details"]["file_pathway"]
 
     # specify file types - this will only show these files when the dialog box opens up
-    filetypes = (('csv files', '*.csv'), )
+    filetypes = (("csv files", "*.csv"),)
 
     # grab user credentials
     user = getpass.getuser()
@@ -988,11 +1086,9 @@ if __name__ == "__main__":
 
     try:
         # Check if the user running it has matched records in this file before
-        if 'inProgress' in intro.fileselect.split('/')[-1]:
-
+        if "inProgress" in intro.fileselect.split("/")[-1]:
             # If it is the same user
-            if user in intro.fileselect.split('/')[-1]:
-
+            if user in intro.fileselect.split("/")[-1]:
                 # Dont rename the file
                 renamed_file = intro.fileselect
 
@@ -1000,30 +1096,28 @@ if __name__ == "__main__":
                 filepath_done = f"{'/'.join(renamed_file.split('/')[:-1])}/{renamed_file.split('/')[-1][0:-15]}_DONE.{renamed_file.split('/')[-1].split('.')[-1]}"
 
             else:
-
                 # Rename the file to contain the additional user
                 renamed_file = f"{'/'.join(intro.fileselect.split('/')[:-1])}/{intro.fileselect.split('/')[-1].split('.')[0][0:-11]}_{user}_inProgress.{intro.fileselect.split('/')[-1].split('.')[-1]}"
-                os.rename(rf'{intro.fileselect}', rf'{renamed_file}')
+                os.rename(rf"{intro.fileselect}", rf"{renamed_file}")
 
                 # create the filepath name for when the file is finished
                 filepath_done = f"{'/'.join(renamed_file.split('/')[:-1])}/{renamed_file.split('/')[-1][0:-15]}_DONE.{renamed_file.split('/')[-1].split('.')[-1]}"
 
         # If a user is picking this file again and its done
-        elif 'DONE' in intro.fileselect.split('/')[-1]:
-
+        elif "DONE" in intro.fileselect.split("/")[-1]:
             # If it is the same user
-            if user in intro.fileselect.split('/')[-1]:
+            if user in intro.fileselect.split("/")[-1]:
                 # dont change filepath done - keep it as it is
                 filepath_done = intro.fileselect
 
                 # Rename the file
                 renamed_file = f"{'/'.join(intro.fileselect.split('/')[:-1])}/{intro.fileselect.split('/')[-1][0:-9]}_inProgress.{intro.fileselect.split('/')[-1].split('.')[-1]}"
-                os.rename(rf'{intro.fileselect}', rf'{renamed_file}')
+                os.rename(rf"{intro.fileselect}", rf"{renamed_file}")
             else:
                 # If it is a different user
                 # Rename the file to include the additional user
                 renamed_file = f"{'/'.join(intro.fileselect.split('/')[:-1])}/{intro.fileselect.split('/')[-1].split('.')[0][0:-5]}_{user}_inProgress.{intro.fileselect.split('/')[-1].split('.')[-1]}"
-                os.rename(rf'{intro.fileselect}', rf'{renamed_file}')
+                os.rename(rf"{intro.fileselect}", rf"{renamed_file}")
 
                 # create the filepath done
                 filepath_done = f"{'/'.join(renamed_file.split('/')[:-1])}/{renamed_file.split('/')[-1][0:-15]}_DONE.{renamed_file.split('/')[-1].split('.')[-1]}"
@@ -1032,48 +1126,61 @@ if __name__ == "__main__":
             # Resave this file with the user ID at the end so no one else selects it
             # rename it with '_inProgress' and their entered initials
             renamed_file = f"{'/'.join(intro.fileselect.split('/')[:-1])}/{intro.fileselect.split('/')[-1].split('.')[0]}_{user}_inProgress.{intro.fileselect.split('/')[-1].split('.')[-1]}"
-            os.rename(rf'{intro.fileselect}', rf'{renamed_file}')
+            os.rename(rf"{intro.fileselect}", rf"{renamed_file}")
 
             # create the filepath name for when the file is finished
             filepath_done = f"{'/'.join(renamed_file.split('/')[:-1])}/{renamed_file.split('/')[-1][0:-15]}_DONE.{renamed_file.split('/')[-1].split('.')[-1]}"
 
     except PermissionError:
         tkinter.messagebox.showwarning(
-            message="This clerical sample is open in another program. Please close this and restart CROW.")
+            message="This clerical sample is open in another program. Please close this and restart CROW."
+        )
 
     # ---- load in the required csv file as a pandas dataframe (can also do this for excel docs...)
     try:
         working_file = pd.read_csv(renamed_file)
 
     except FileNotFoundError or NameError:
-
         sys.exit(
-            "\n\nThis clerical sample is open in another program. Please close this and restart CROW.")
+            "\n\nThis clerical sample is open in another program. Please close this and restart CROW."
+        )
 
     # data validation step
 
-    record_id = config['record_id_col']['record_id']
-    
-    working_file['duplicated_record'] = np.where(working_file[record_id].duplicated(), 1, 0)
-    
-    duplicates = working_file[working_file['duplicated_record'] == 1][record_id].tolist()
-            
+    record_id = config["record_id_col"]["record_id"]
+
+    working_file["duplicated_record"] = np.where(
+        working_file[record_id].duplicated(), 1, 0
+    )
+
+    duplicates = working_file[working_file["duplicated_record"] == 1][
+        record_id
+    ].tolist()
+
     if len(working_file) != len(working_file[record_id].unique()):
         raise ValueError(f"the record ID(s): {duplicates} is not unique!")
-        
-    del(record_id, duplicates)
-    
-    working_file = working_file.drop(columns = 'duplicated_record')
-    
+
+    del (record_id, duplicates)
+
+    working_file = working_file.drop(columns="duplicated_record")
+
     # END OF STEP 2
 
     # Step 3:
     # Run the Clerical Matching Application
 
     root = tkinter.Tk()
-    mainWindow = ClericalApp(
-        root, working_file, filepath_done, renamed_file, config)
+    mainWindow = ClericalApp(root, working_file, filepath_done, renamed_file, config)
     root.mainloop()
 
-    print("\n Number of records matched:", str(len(working_file[(
-        working_file.Match != 'No match in cluster') & (working_file.Match != "")])))
+    print(
+        "\n Number of records matched:",
+        str(
+            len(
+                working_file[
+                    (working_file.Match != "No match in cluster")
+                    & (working_file.Match != "")
+                ]
+            )
+        ),
+    )

--- a/version1_tkinter/CROW_clusters.py
+++ b/version1_tkinter/CROW_clusters.py
@@ -140,48 +140,42 @@ class ClericalApp:
 
         # 2 - Record Frame: Create a container to hold the scrollable
         # canvas that will contain the record frame.
-        container = ttk.Labelframe(root, text="Records")
-        container.grid(row=1, column=0, padx=10, sticky="nsew")
+        self.record_container = ttk.Labelframe(root, text="Records")
+        self.record_container.grid(row=1, column=0, padx=10, sticky="nsew")
 
         # Create the canvas and scrollbars. Attach the scrollbar
         # functionality to the canvas.
-        canvas = tkinter.Canvas(container)
-        vertical_scrollbar = ttk.Scrollbar(
-            container, orient="vertical", command=canvas.yview
+        self.canvas = tkinter.Canvas(self.record_container)
+        self.vertical_scrollbar = ttk.Scrollbar(
+            self.record_container, orient="vertical", command=self.canvas.yview
         )
-        horizontal_scrollbar = ttk.Scrollbar(
-            container, orient="horizontal", command=canvas.xview
+        self.horizontal_scrollbar = ttk.Scrollbar(
+            self.record_container, orient="horizontal", command=self.canvas.xview
         )
-        canvas.configure(
-            yscrollcommand=vertical_scrollbar.set,
-            xscrollcommand=horizontal_scrollbar.set,
-        )
-
-        # Bind the mousewheel to the scrolling.
-        self.root.bind_all(
-            "<MouseWheel>",
-            lambda e: canvas.yview_scroll(-1 * int(e.delta / 120), "units"),
-        )
-        self.root.bind_all(
-            "<Shift-MouseWheel>",
-            lambda e: canvas.xview_scroll(-1 * int(e.delta / 120), "units"),
+        self.canvas.configure(
+            yscrollcommand=self.vertical_scrollbar.set,
+            xscrollcommand=self.horizontal_scrollbar.set,
         )
 
         # Add the scrollbars and canvas to the window.
-        vertical_scrollbar.pack(side="right", fill="y")
-        horizontal_scrollbar.pack(side="bottom", fill="x")
-        canvas.pack(side="left", fill="both", expand=True)
+        self.vertical_scrollbar.pack(side="right", fill="y")
+        self.horizontal_scrollbar.pack(side="bottom", fill="x")
+        self.canvas.pack(side="left", fill="both", expand=True)
 
-        # Create the record frame.
-        self.record_frame = ttk.Frame(canvas)
+        # Create the record frame. Place the record frame in the canvas.
+        self.record_frame = ttk.Frame(self.canvas)
+        self.canvas.create_window((0, 0), window=self.record_frame, anchor="nw")
 
-        # Place the record frame in the canvas.
-        canvas.create_window((0, 0), window=self.record_frame, anchor="nw")
+        self.record_frame.bind("<Configure>", self._on_record_frame_configure)
 
-        # Make sure the scrollbars update whenever the record frame
-        # grows beyond the viewport.
-        self.record_frame.bind(
-            "<Configure>", lambda _: canvas.configure(scrollregion=canvas.bbox("all"))
+        # Bind the mousewheel to the scrolling.
+        self.canvas.bind_all(
+            "<MouseWheel>",
+            lambda e: self.canvas.yview_scroll(-1 * int(e.delta / 120), "units"),
+        )
+        self.canvas.bind_all(
+            "<Shift-MouseWheel>",
+            lambda e: self.canvas.xview_scroll(-1 * int(e.delta / 120), "units"),
         )
 
         # 2 - Button Frame
@@ -281,6 +275,13 @@ class ClericalApp:
         self.draw_recordframe(config, working_file)
         self.draw_button_frame()
         self.draw_tool_frame()
+
+    def _on_record_frame_configure(self, event: tkinter.Event) -> None:
+        """Ensure scrollregion is as tall as the canvas."""
+        x1, y1, x2, y2 = self.canvas.bbox("all")
+        canvas_height = self.canvas.winfo_height()
+        bottom = max(y2, canvas_height)
+        self.canvas.configure(scrollregion=(x1, y1, x2, bottom))
 
     def get_starting_cluster_id(self):
         """

--- a/version1_tkinter/CROW_pairwise.py
+++ b/version1_tkinter/CROW_pairwise.py
@@ -120,9 +120,51 @@ class ClericalApp:
             row=0, column=0, columnspan=1, sticky="ew", padx=10, pady=10
         )
 
-        # 2 - Record Frame
-        self.record_frame = ttk.LabelFrame(root, text="Current Record")
-        self.record_frame.grid(row=1, column=0, columnspan=1, padx=10, pady=3)
+        # 2 - Record Frame: Create a container to hold the scrollable
+        # canvas that will contain the record frame.
+        container = ttk.Labelframe(root, text="Records")
+        container.grid(row=1, column=0, padx=10, sticky="nsew")
+
+        # Create the canvas and scrollbars. Attach the scrollbar
+        # functionality to the canvas.
+        canvas = tkinter.Canvas(container)
+        vertical_scrollbar = ttk.Scrollbar(
+            container, orient="vertical", command=canvas.yview
+        )
+        horizontal_scrollbar = ttk.Scrollbar(
+            container, orient="horizontal", command=canvas.xview
+        )
+        canvas.configure(
+            yscrollcommand=vertical_scrollbar.set,
+            xscrollcommand=horizontal_scrollbar.set,
+        )
+
+        # Bind the mousewheel to the scrolling.
+        self.root.bind_all(
+            "<MouseWheel>",
+            lambda e: canvas.yview_scroll(-1 * int(e.delta / 120), "units"),
+        )
+        self.root.bind_all(
+            "<Shift-MouseWheel>",
+            lambda e: canvas.xview_scroll(-1 * int(e.delta / 120), "units"),
+        )
+
+        # Add the scrollbars and canvas to the window.
+        vertical_scrollbar.pack(side="right", fill="y")
+        horizontal_scrollbar.pack(side="bottom", fill="x")
+        canvas.pack(side="left", fill="both", expand=True)
+
+        # Create the record frame.
+        self.record_frame = ttk.Frame(canvas)
+
+        # Place the record frame in the canvas.
+        canvas.create_window((0, 0), window=self.record_frame, anchor="nw")
+
+        # Make sure the scrollbars update whenever the record frame
+        # grows beyond the viewport.
+        self.record_frame.bind(
+            "<Configure>", lambda _: canvas.configure(scrollregion=canvas.bbox("all"))
+        )
 
         # 3 -Button Frame
         self.button_frame = ttk.Frame(root)

--- a/version1_tkinter/CROW_pairwise.py
+++ b/version1_tkinter/CROW_pairwise.py
@@ -108,6 +108,11 @@ class ClericalApp:
         height = int(self.root.winfo_screenheight() * 0.5)
         self.root.geometry(f"{width}x{height}")
 
+        # Configure the grid layout to make sure the record frame can
+        # expand to fill the window.
+        self.root.grid_columnconfigure(0, weight=1)
+        self.root.grid_rowconfigure(1, weight=1)
+
         # Create the separate frames
         # 1 - Tool Frame
         self.toolFrame = ttk.LabelFrame(root, text="Tools:")
@@ -117,11 +122,11 @@ class ClericalApp:
 
         # 2 - Record Frame
         self.record_frame = ttk.LabelFrame(root, text="Current Record")
-        self.record_frame.grid(row=2, column=0, columnspan=1, padx=10, pady=3)
+        self.record_frame.grid(row=1, column=0, columnspan=1, padx=10, pady=3)
 
         # 3 -Button Frame
-        self.button_frame = ttk.LabelFrame(root)
-        self.button_frame.grid(row=3, column=0, columnspan=1, padx=10, pady=3)
+        self.button_frame = ttk.Frame(root)
+        self.button_frame.grid(row=2, column=0, columnspan=1, padx=10, pady=10)
 
         # create protocol for if user presses the 'X' (top right)
         root.protocol("WM_DELETE_WINDOW", self.on_exit)

--- a/version1_tkinter/CROW_pairwise.py
+++ b/version1_tkinter/CROW_pairwise.py
@@ -122,48 +122,45 @@ class ClericalApp:
 
         # 2 - Record Frame: Create a container to hold the scrollable
         # canvas that will contain the record frame.
-        container = ttk.Labelframe(root, text="Records")
-        container.grid(row=1, column=0, padx=10, sticky="nsew")
+        self.record_container = ttk.Labelframe(root, text="Records")
+        self.record_container.grid(row=1, column=0, padx=10, sticky="nsew")
 
         # Create the canvas and scrollbars. Attach the scrollbar
         # functionality to the canvas.
-        canvas = tkinter.Canvas(container)
-        vertical_scrollbar = ttk.Scrollbar(
-            container, orient="vertical", command=canvas.yview
+        self.canvas = tkinter.Canvas(self.record_container)
+        self.vertical_scrollbar = ttk.Scrollbar(
+            self.record_container, orient="vertical", command=self.canvas.yview
         )
-        horizontal_scrollbar = ttk.Scrollbar(
-            container, orient="horizontal", command=canvas.xview
+        self.horizontal_scrollbar = ttk.Scrollbar(
+            self.record_container, orient="horizontal", command=self.canvas.xview
         )
-        canvas.configure(
-            yscrollcommand=vertical_scrollbar.set,
-            xscrollcommand=horizontal_scrollbar.set,
-        )
-
-        # Bind the mousewheel to the scrolling.
-        self.root.bind_all(
-            "<MouseWheel>",
-            lambda e: canvas.yview_scroll(-1 * int(e.delta / 120), "units"),
-        )
-        self.root.bind_all(
-            "<Shift-MouseWheel>",
-            lambda e: canvas.xview_scroll(-1 * int(e.delta / 120), "units"),
+        self.canvas.configure(
+            yscrollcommand=self.vertical_scrollbar.set,
+            xscrollcommand=self.horizontal_scrollbar.set,
         )
 
         # Add the scrollbars and canvas to the window.
-        vertical_scrollbar.pack(side="right", fill="y")
-        horizontal_scrollbar.pack(side="bottom", fill="x")
-        canvas.pack(side="left", fill="both", expand=True)
+        self.vertical_scrollbar.pack(side="right", fill="y")
+        self.horizontal_scrollbar.pack(side="bottom", fill="x")
+        self.canvas.pack(side="left", fill="both", expand=True)
 
-        # Create the record frame.
-        self.record_frame = ttk.Frame(canvas)
-
-        # Place the record frame in the canvas.
-        canvas.create_window((0, 0), window=self.record_frame, anchor="nw")
+        # Create the record frame.Place the record frame in the canvas.
+        self.record_frame = ttk.Frame(self.canvas)
+        self.canvas.create_window((0, 0), window=self.record_frame, anchor="nw")
 
         # Make sure the scrollbars update whenever the record frame
         # grows beyond the viewport.
-        self.record_frame.bind(
-            "<Configure>", lambda _: canvas.configure(scrollregion=canvas.bbox("all"))
+        self.record_frame.bind("<Configure>", self._on_record_frame_configure)
+
+        # Bind the mousewheel events for vertical and horizontal
+        # scrolling.
+        self.canvas.bind_all(
+            "<MouseWheel>",
+            lambda e: self.canvas.yview_scroll(int(-1 * (e.delta / 120)), "units"),
+        )
+        self.canvas.bind_all(
+            "<Shift-MouseWheel>",
+            lambda e: self.canvas.xview_scroll(int(-1 * (e.delta / 120)), "units"),
         )
 
         # 3 -Button Frame
@@ -246,6 +243,13 @@ class ClericalApp:
         self.draw_tool_frame()
         # ---------------------
         # Create dataset name widgets and separators between
+
+    def _on_record_frame_configure(self, event: tkinter.Event) -> None:
+        """Ensure scrollregion is as tall as the canvas."""
+        x1, y1, x2, y2 = self.canvas.bbox("all")
+        canvas_height = self.canvas.winfo_height()
+        bottom = max(y2, canvas_height)
+        self.canvas.configure(scrollregion=(x1, y1, x2, bottom))
 
     def draw_record_frame(self):
         row_adder = 0

--- a/version1_tkinter/CROW_pairwise.py
+++ b/version1_tkinter/CROW_pairwise.py
@@ -237,20 +237,6 @@ class ClericalApp:
         self.show_hide_diff = 0
         self.difference_col_label_names = {}
 
-        # Create the record_index matches
-        self.counter_matches = ttk.Label(
-            self.record_frame,
-            text=f"{self.record_index + 1} / {self.num_records} Records",
-            font="Helvetica 9",
-        )
-        self.counter_matches.grid(
-            row=0,
-            column=len(config.options("column_headers_and_order")),
-            columnspan=1,
-            padx=10,
-            sticky="e",
-        )
-
         # Create empty lists of labels
         self.non_iterated_labels = []
         self.iterated_labels = []
@@ -264,19 +250,6 @@ class ClericalApp:
     def draw_record_frame(self):
         row_adder = 0
         separator_adder = 2
-
-        self.counter_matches = ttk.Label(
-            self.record_frame,
-            text=f"{self.record_index + 1} / {self.num_records} Records",
-            font="Helvetica 9",
-        )
-        self.counter_matches.grid(
-            row=0,
-            column=len(config.options("column_headers_and_order")),
-            columnspan=1,
-            padx=10,
-            sticky="e",
-        )
 
         for iterator, name_of_dataset in enumerate(config.options("dataset_names")):
             exec(
@@ -489,6 +462,10 @@ class ClericalApp:
         # =====  toolFrame
 
     def draw_tool_frame(self):
+        # Configure the grid so the record counter can move to the right
+        # of the tool frame.
+        self.toolFrame.grid_columnconfigure(9, weight=1)
+
         # Create labels for tools bar
         self.separator_tf_1 = ttk.Separator(self.toolFrame, orient="vertical")
         self.separator_tf_1.grid(
@@ -558,6 +535,13 @@ class ClericalApp:
             command=lambda: self.save_and_close(),
         )
         self.save_button.grid(row=0, column=8, columnspan=1, sticky="e", padx=5, pady=5)
+
+        # Current record pair counter.
+        count_msg = f"Record pair: {self.record_index + 1} / {self.num_records}"
+        self.counter_matches = ttk.Label(
+            self.toolFrame, text=count_msg, font=f"Helvetica {self.text_size}"
+        )
+        self.counter_matches.grid(row=0, column=9, padx=10, sticky="e")
 
     def show_hide_differences(self):
         if not self.show_hide_diff:

--- a/version1_tkinter/CROW_pairwise.py
+++ b/version1_tkinter/CROW_pairwise.py
@@ -1,16 +1,16 @@
 """
 Welcome to CROW, the Clerical Resolution Online Widget, an open source project
 designed to help researchers, analysts and statiticians with their clerical
-matching needs once they have linked data together. 
-This is the master CROW python script that can easily be adapted to your linkage 
-project using the Config.ini file. To make the CROW work please edit the Config 
-file, its easier to read and will save you time! 
+matching needs once they have linked data together.
+This is the master CROW python script that can easily be adapted to your linkage
+project using the Config.ini file. To make the CROW work please edit the Config
+file, its easier to read and will save you time!
 Once you have adapted the Config file and have tested it. Put this master CROW
-python script along with your adapted config file in a shared common area 
+python script along with your adapted config file in a shared common area
 so the rest of your clerical matchers can access it. DONT forget to save this
-file as read-only. And then you are done! 
-More detail on these steps can be found on the Data Integration Sharepoint, 
-including video documentation. 
+file as read-only. And then you are done!
+More detail on these steps can be found on the Data Integration Sharepoint,
+including video documentation.
 Script was orginally created on Wed May 26 2021
 Please get in contact using the below details if you have any questions:
 Craig Scott -- Craig.Scott@ons.gov.uk -- Creator and Lead Developer
@@ -18,11 +18,13 @@ Hannah O'Dair -- Hannah.O'Dair@ons.gov.uk -- Co-Lead Developer
 _________
 We would like to acknowledge and thank David Cobbledick and Andrew Sutton for reviewing this code.
 """
-import os
-import getpass
+
 import configparser
+import getpass
+import os
 import tkinter
-from tkinter import ttk, filedialog
+from tkinter import filedialog, ttk
+
 import pandas as pd
 
 ########## Intro GUI
@@ -36,7 +38,6 @@ class IntroWindow:
     """
 
     def __init__(self, root, init_dir, files_info):
-
         # Initialise the gui paramaters
         root.geometry("400x225")
         root.title("Clerical Matching")
@@ -92,9 +93,20 @@ class ClericalApp:
     """
 
     def __init__(self, root, working_file, filename_done, filename_old, config):
+        """Initialise the ClericalApp class."""
+        # Initialise some parameters.
+        self.root = root
+        self.filename_done = filename_done
+        self.filename_old = filename_old
 
-        # Create a title
+        # Set the window title.
         root.title("Clerical Matching")
+
+        # Set the window size to 90% of screen width and 50% of screen
+        # height.
+        width = int(self.root.winfo_screenwidth() * 0.9)
+        height = int(self.root.winfo_screenheight() * 0.5)
+        self.root.geometry(f"{width}x{height}")
 
         # Create the separate frames
         # 1 - Tool Frame
@@ -111,31 +123,22 @@ class ClericalApp:
         self.button_frame = ttk.LabelFrame(root)
         self.button_frame.grid(row=3, column=0, columnspan=1, padx=10, pady=3)
 
-        # initalise the file name variables
-        self.filename_done = filename_done
-
-        self.filename_old = filename_old
-
         # create protocol for if user presses the 'X' (top right)
         root.protocol("WM_DELETE_WINDOW", self.on_exit)
 
         # create a match column if one doesn't exist
         # replace any missing values (NA) with blank spaces
         if {"Match"}.issubset(working_file.columns):
-
             # convert all columns apart from Match and Comments (if specified) to string
             for col_header in working_file.columns:
-
-                if col_header in ('Match', 'Comments'):
+                if col_header in ("Match", "Comments"):
                     pass
                 else:
                     # convert to string
                     working_file[col_header] = working_file[col_header].astype(str)
                     # remove nan values
                     for i in range(len(working_file)):
-
                         if working_file[col_header][i] == "nan":
-
                             working_file.at[i, col_header] = ""
 
             working_file.fillna("", inplace=True)
@@ -150,17 +153,14 @@ class ClericalApp:
 
             # convert all columns apart from Match and Comments (if specified) to string
             for col_header in working_file.columns:
-
-                if col_header in ('Match', 'Comments'):
+                if col_header in ("Match", "Comments"):
                     pass
                 else:
                     # convert to string
                     working_file[col_header] = working_file[col_header].astype(str)
                     # remove nan values
                     for i in range(len(working_file)):
-
                         if working_file[col_header][i] == "nan":
-
                             working_file.at[i, col_header] = ""
 
             working_file.fillna("", inplace=True)
@@ -193,7 +193,7 @@ class ClericalApp:
         # Create the record_index matches
         self.counter_matches = ttk.Label(
             self.record_frame,
-            text=f"{self.record_index+1} / {self.num_records} Records",
+            text=f"{self.record_index + 1} / {self.num_records} Records",
             font="Helvetica 9",
         )
         self.counter_matches.grid(
@@ -220,7 +220,7 @@ class ClericalApp:
 
         self.counter_matches = ttk.Label(
             self.record_frame,
-            text=f"{self.record_index+1} / {self.num_records} Records",
+            text=f"{self.record_index + 1} / {self.num_records} Records",
             font="Helvetica 9",
         )
         self.counter_matches.grid(
@@ -232,7 +232,6 @@ class ClericalApp:
         )
 
         for iterator, name_of_dataset in enumerate(config.options("dataset_names")):
-
             exec(
                 f'self.{name_of_dataset} = ttk.Label(self.record_frame,text=config["dataset_names"]["{name_of_dataset}"]+":",font=f"Helvetica {self.text_size} bold")'
             )
@@ -259,13 +258,14 @@ class ClericalApp:
         # ---------------------
         # Create column header widgets
         self.datasource_label = ttk.Label(
-            self.record_frame, text="Datasource", font=f"Helvetica {self.text_size} bold"
+            self.record_frame,
+            text="Datasource",
+            font=f"Helvetica {self.text_size} bold",
         )
         self.datasource_label.grid(row=1, column=0, columnspan=1, padx=10, pady=3)
 
         # Create column header labels and place all them on row 1
         for column_title in config.options("column_headers_and_order"):
-
             # Remove spaces from the user input and split them into different components
 
             col_header = (
@@ -305,7 +305,6 @@ class ClericalApp:
         dataset_names_to_highlight = []
         # collect the dataset names entered
         for dataset_names in config.options("dataset_names"):
-
             dataset_names_to_highlight.append(config["dataset_names"][dataset_names])
 
         # remove the first dataset as this is the highlighted one.
@@ -319,7 +318,6 @@ class ClericalApp:
         i = 0
 
         for columnfile_title in config.options("columnfile_info_and_order"):
-
             # Remove spaces from the user input and split them into different components
             col_header = (
                 config["columnfile_info_and_order"][columnfile_title]
@@ -342,7 +340,6 @@ class ClericalApp:
 
             # cycle through each dataset name to know which row to put the label on
             for name in name_of_datasets:
-
                 if col_header[1] == name:
                     # Colheader has matched
 
@@ -353,19 +350,15 @@ class ClericalApp:
 
                     # check whether it is a dataset row to highlight or not
                     if col_header[1] in dataset_names_to_highlight:
-
                         if col_header[2] in self.datarows_to_highlight:
-
                             self.datarows_to_highlight[col_header[2]].append(
                                 col_header[0]
                             )
 
                         else:
-
                             self.datarows_to_highlight[col_header[2]] = [col_header[0]]
 
                     else:
-
                         self.datarow_to_compare[col_header[2]] = [col_header[0]]
                     # break the for loop if name has been resolved
                     break
@@ -395,7 +388,6 @@ class ClericalApp:
         # =====  record_frame
 
     def draw_button_frame(self):
-
         # Match/Non-Match buttons
         self.match_button = tkinter.Button(
             self.button_frame,
@@ -416,7 +408,6 @@ class ClericalApp:
 
         # Add in the comment widget based on config option
         if int(config["custom_settings"]["commentbox"]):
-
             # create comments column if one doesn't exist
             if "Comments" not in working_file:
                 working_file["Comments"] = ""
@@ -451,7 +442,6 @@ class ClericalApp:
         # =====  toolFrame
 
     def draw_tool_frame(self):
-
         # Create labels for tools bar
         self.separator_tf_1 = ttk.Separator(self.toolFrame, orient="vertical")
         self.separator_tf_1.grid(
@@ -463,7 +453,7 @@ class ClericalApp:
         )
 
         # Back button
-        back_symbol = "\u23CE"
+        back_symbol = "\u23ce"
         self.back_button = tkinter.Button(
             self.button_frame,
             text=f"Back {back_symbol}",
@@ -480,8 +470,8 @@ class ClericalApp:
         )
         self.showhidediff.grid(row=0, column=2, columnspan=1, padx=5, pady=5)
         # Change text size buttons
-        increase_text_size_symbol = "\U0001F5DA"
-        decrease_text_size_symbol = "\U0001F5DB"
+        increase_text_size_symbol = "\U0001f5da"
+        decrease_text_size_symbol = "\U0001f5db"
 
         self.text_smaller_button = tkinter.Button(
             self.toolFrame,
@@ -502,7 +492,7 @@ class ClericalApp:
         )
         self.text_bigger_button.grid(row=0, column=5, sticky="w", pady=5, padx=2)
         # Make text bld button
-        bold_symbol = "\U0001D5D5"
+        bold_symbol = "\U0001d5d5"
         self.bold_button = tkinter.Button(
             self.toolFrame,
             text=f"{bold_symbol}",
@@ -513,7 +503,7 @@ class ClericalApp:
         )
         self.bold_button.grid(row=0, column=6, sticky="w", pady=5)
         # Save and close button
-        save_symbol = "\U0001F4BE"
+        save_symbol = "\U0001f4be"
         self.save_button = tkinter.Button(
             self.toolFrame,
             text=f"Save and Close {save_symbol}",
@@ -523,7 +513,6 @@ class ClericalApp:
         self.save_button.grid(row=0, column=8, columnspan=1, sticky="e", padx=5, pady=5)
 
     def show_hide_differences(self):
-
         if not self.show_hide_diff:
             # make show show diff variable 1 so that next time this function is
             # called it will remove tags
@@ -534,10 +523,8 @@ class ClericalApp:
 
             # for key in datarows that need to be highlighted
             for key in self.datarows_to_highlight:
-
                 # For the values in datarows that need to be highlighted
                 for vals in self.datarows_to_highlight[key]:
-
                     # some empty variables to control the flow of the difference indicator
                     char_consistent = []
                     container = []
@@ -553,10 +540,8 @@ class ClericalApp:
                         ],
                         working_file[f"{vals}"][self.record_index],
                     ):
-
                         # if the comparison char is not the same as the highlighter char
                         if char_comparison != char_highlight:
-
                             # if this is the first diff then remove them
                             if string_start:
                                 # start the container values
@@ -574,13 +559,11 @@ class ClericalApp:
                                 - 1,
                                 len(working_file[f"{vals}"][self.record_index]) - 1,
                             ):
-
                                 container.append(count + 1)
                                 # pass this start and end values to the overall container
                                 char_consistent.append(container)
 
                         else:
-
                             # if string end == string start
                             if string_end == string_start:
                                 # add it to the container to complete the char number
@@ -601,7 +584,6 @@ class ClericalApp:
                     if len(
                         working_file[self.datarow_to_compare[key][0]][self.record_index]
                     ) < len(working_file[f"{vals}"][self.record_index]):
-
                         char_consistent.append(
                             [
                                 len(
@@ -617,15 +599,12 @@ class ClericalApp:
 
                     # for each tag number in char consistent create the tag and save the tag name information
                     for tag_adder in range(len(char_consistent)):
-
                         if vals in self.difference_col_label_names:
-
                             self.difference_col_label_names[vals].append(
                                 f"{vals}_diff{str(tag_adder)}"
                             )
 
                         else:
-
                             self.difference_col_label_names[vals] = [
                                 f"{vals}_diff{str(tag_adder)}"
                             ]
@@ -643,9 +622,7 @@ class ClericalApp:
             self.show_hide_diff = 0
             # for all variable labels with differences - remove the tag labels
             for key in self.difference_col_label_names:
-
                 for vals in self.difference_col_label_names[key]:
-
                     exec(f"self.{key}.tag_remove('{vals}','1.0','end')")
 
     def make_text_bold(self):
@@ -666,7 +643,6 @@ class ClericalApp:
         self.update_gui()
 
     def get_starting_index(self):
-
         """
         This function finds the first row in column index [-1] that has a value not equal to zero or 1
         and returns the index number
@@ -688,7 +664,6 @@ class ClericalApp:
 
         # Choose which one to cycle through
         if int(config["custom_settings"]["commentbox"]):
-
             for i in index_values:
                 if working_file.iloc[i, -2] != 1 and working_file.iloc[i, -2] != 0:
                     return i
@@ -698,7 +673,6 @@ class ClericalApp:
                     pass
 
         else:
-
             for i in index_values:
                 if working_file.iloc[i, -1] != 1 and working_file.iloc[i, -1] != 0:
                     return i
@@ -723,21 +697,17 @@ class ClericalApp:
         if self.check_matching_done() == 0:
             # configure the non-iterable labels
             for non_iter_columns in self.non_iterated_labels:
-
                 exec(
                     f'self.{non_iter_columns}.config(font=f"Helvetica {self.text_size} bold")'
                 )
 
             for widget in self.record_frame.winfo_children():
-
                 widget.destroy()
 
             for widget in self.toolFrame.winfo_children():
-
                 widget.destroy()
 
             for widget in self.button_frame.winfo_children():
-
                 widget.destroy()
             self.draw_record_frame()
             self.draw_button_frame()
@@ -832,7 +802,6 @@ class ClericalApp:
 
             return 1
         else:
-
             return 0
 
     def save_and_close(self):
@@ -923,7 +892,6 @@ class ClericalApp:
             if len(working_file) % self.records_per_checkpoint == 0:
                 os.rename(self.filename_done, self.filename_old)
         elif self.record_index > 0:  # If they are part way through matching
-
             # update the record_index
             self.record_index = self.record_index - 1
             # update the gui
@@ -962,8 +930,9 @@ class ClericalApp:
 
         """
         # if they click yes
-        if tkinter.messagebox.askyesno("Exit", "Are you sure you want to exit WITHOUT saving?"):
-
+        if tkinter.messagebox.askyesno(
+            "Exit", "Are you sure you want to exit WITHOUT saving?"
+        ):
             # check if this is the first time they are accessing it
             if not self.matching_previously_began & self.checkpointcounter != 0:
                 # then rename the file removing their intial and 'inProgress' tag
@@ -977,7 +946,6 @@ class ClericalApp:
 
 
 if __name__ == "__main__":
-
     # ------
     # Step 1:
     # Load config file and get the file directory
@@ -1016,10 +984,8 @@ if __name__ == "__main__":
 
     # Check if the user running it has selected this file before (this means they have done some of the matching already and are coming back to it)
     if "inProgress" in intro.fileselect.split("/")[-1]:
-
         # If it is the same user
         if user in intro.fileselect.split("/")[-1]:
-
             # Dont rename the file
             renamed_file = intro.fileselect
 
@@ -1027,7 +993,6 @@ if __name__ == "__main__":
             filepath_done = f"{'/'.join(renamed_file.split('/')[:-1])}/{renamed_file.split('/')[-1][0:-15]}_DONE.{renamed_file.split('/')[-1].split('.')[-1]}"
 
         else:
-
             # Rename the file to contain the additional user
             renamed_file = f"{'/'.join(intro.fileselect.split('/')[:-1])}/{intro.fileselect.split('/')[-1].split('.')[0][0:-11]}_{user}_inProgress.{intro.fileselect.split('/')[-1].split('.')[-1]}"
             os.rename(rf"{intro.fileselect}", rf"{renamed_file}")
@@ -1037,7 +1002,6 @@ if __name__ == "__main__":
 
     # If a user is picking this file again and its done
     elif "DONE" in intro.fileselect.split("/")[-1]:
-
         # If it is the same user
         if user in intro.fileselect.split("/")[-1]:
             # dont change filepath done - keep it as it is

--- a/version1_tkinter/README.md
+++ b/version1_tkinter/README.md
@@ -3,7 +3,7 @@
 Here you will find everything you need to get started with the tkinter version
 of CROW.
 
-The docs folder contains guidance on the setup and use of CROW1.
+The `docs` folder contains guidance on the setup and use of CROW1.
 
 ## Utils
 


### PR DESCRIPTION
The following changes apply to both the pairwise and cluster versions of CROW1:

- The initial width and height of the window has been fixed. The screen size can still be manually adjusted by dragging the sides of the window.
- The grid row layout has been configured such that the record frame can expand to fill the available space in the window. The grid column layout has been configured so each frame fills the window. The column layout change along with the width and height change above results in the button frame being fixed and not jumping around between record pairs/clusters.
- The record frame is placed within a canvas within a container. Scrollbars are attached to the canvas. Now, when the data being displayed is wider or taller than the window it will no longer disappear off the edges. Instead, it will overflow and the scrollbars can be used to reach it.
- The scrollbars can be used by clicking and dragging, or using the mouse wheel to scroll vertically and shift + mouse wheel to scroll horizontally.
- The record/cluster counter has been moved from the top right-hand side of the record frame to the right-hand side of the tool frame. This is now in a fixed position and always visible on the window.
- Some minor formatting done automatically with [Ruff](https://docs.astral.sh/ruff/) e.g. sorted imports, converted some single quotes to double quotes, reorganised some line length violations, and removed some unnecessary whitespace and blank lines.